### PR TITLE
Add another caching mechanism

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -413,6 +413,63 @@ class Task(abc.ABC):
         self._training_docs = None
         self._fewshot_docs = None
 
+    def _get_cache_path(self, args, kwargs, cache_dir):
+        """Return the path of the cached version of the task dataset.
+
+        :param args: tuple
+            Positional arguments passed to `datasets.load_dataset`.
+        :param kwargs: dict[str, Any]
+            Keyword arguments passed to `datasets.load_dataset`.
+        :param cache_dir: Union[str, Path, None]
+            The directory to read/write the `Task` dataset from/to. This
+            follows the HuggingFace `datasets` API with the default
+            cache directory located at:
+                `~/.cache/huggingface/datasets`
+            NOTE: You can change the cache location globally for a given
+            process by setting the shell environment variable,
+            `HF_DATASETS_CACHE`, to another directory:
+                `export HF_DATASETS_CACHE="/path/to/another/directory"`
+        """
+        if not cache_dir:
+            cache_dir = datasets.config.HF_DATASETS_CACHE
+        cache_name = self._get_cache_name(args, kwargs)
+        return os.path.join(cache_dir, cache_name)
+
+    def _get_cache_name(self, args, kwargs):
+        """Return the file name of the cached version of the task dataset.
+
+        :param args: tuple
+            Positional arguments passed to `datasets.load_dataset`.
+        :param kwargs: dict[str, Any]
+            Keyword arguments passed to `datasets.load_dataset`.
+        """
+        assert isinstance(args, tuple) and isinstance(kwargs, dict), (
+            'positional arguments must be tuple and keyword arguments must '
+            'be dictionary for getting cache name'
+        )
+        # Try to get the `path`.
+        if args:
+            name = args[0]
+        elif 'path' in kwargs:
+            name = kwargs['path']
+        elif self.DATASET_PATH:
+            name = self.DATASET_PATH
+        # Try to get the `name`.
+        elif len(args) > 1:
+            name = args[1]
+        elif 'name' in kwargs:
+            name = kwargs['name']
+        elif self.DATASET_NAME:
+            name = self.DATASET_NAME
+        else:
+            raise ValueError('cannot find a dataset name')
+
+        # Similar to what the usual `datasets` caching does.
+        name = name.replace('/', '--').replace('\0', '-0-')
+        hasher = datasets.fingerprint.Hasher()
+        hashed_all_args = hasher.hash((args, kwargs))
+        return f'{name}_{hashed_all_args}'
+
     def download(self, data_dir=None, cache_dir=None, download_mode=None):
         """Downloads and returns the task dataset.
         Override this method to download the dataset from a custom API.
@@ -445,6 +502,66 @@ class Task(abc.ABC):
             cache_dir=cache_dir,
             download_mode=download_mode,
         )
+
+    def _download_pushed(
+            self,
+            args,
+            kwargs,
+            data_dir=None,
+            cache_dir=None,
+            download_mode=None,
+    ):
+        """Download and assign a task dataset that was pushed to the hub
+        (i.e. the usual `download` API does not work in offline mode).
+        See https://github.com/huggingface/datasets/issues/3547.
+
+        :param args: tuple
+            Positional arguments passed to `datasets.load_dataset`.
+        :param kwargs: dict[str, Any]
+            Keyword arguments passed to `datasets.load_dataset`.
+        :param data_dir: Optional[str]
+            Stores the path to a local folder containing the `Task`'s data files.
+            Use this to specify the path to manually downloaded data (usually when
+            the dataset is not publicly accessible).
+        :param cache_dir: Optional[str]
+            The directory to read/write the `Task` dataset. This follows the
+            HuggingFace `datasets` API with the default cache directory located at:
+                `~/.cache/huggingface/datasets`
+            NOTE: You can change the cache location globally for a given process
+            by setting the shell environment variable, `HF_DATASETS_CACHE`,
+            to another directory:
+                `export HF_DATASETS_CACHE="/path/to/another/directory"`
+        :param download_mode: Optional[datasets.DownloadMode]
+            How to treat pre-existing `Task` downloads and data.
+            - `datasets.DownloadMode.REUSE_DATASET_IF_EXISTS`
+                Reuse download and reuse dataset.
+            - `datasets.DownloadMode.REUSE_CACHE_IF_EXISTS`
+                Reuse download with fresh dataset.
+            - `datasets.DownloadMode.FORCE_REDOWNLOAD`
+                Fresh download and fresh dataset.
+
+        """
+        if 'data_dir' in kwargs:
+            data_dir = kwargs.pop('data_dir')
+        if 'cache_dir' in kwargs:
+            cache_dir = kwargs.pop('cache_dir')
+        if 'download_mode' in kwargs:
+            download_mode = kwargs.pop('download_mode')
+
+        cached_path = self._get_cache_path(args, kwargs, cache_dir)
+        if not datasets.config.HF_DATASETS_OFFLINE:
+            self.dataset = datasets.load_dataset(
+                *args,
+                data_dir=data_dir,
+                cache_dir=cache_dir,
+                download_mode=download_mode,
+                **kwargs,
+            )
+            # Primitive since we don't store a time stamp, but should be
+            # good enough.
+            self.dataset.save_to_disk(cached_path)
+        else:
+            self.dataset = datasets.load_from_disk(cached_path)
 
     def should_decontaminate(self):
         """Whether this task supports decontamination against model training set."""

--- a/lm_eval/tasks/german_europarl_ppl.py
+++ b/lm_eval/tasks/german_europarl_ppl.py
@@ -39,13 +39,14 @@ class GermanEuroparlPerplexity(PerplexityTask):
             "https://nlpado.de/~sebastian/software/ner/ep-96-04-15.conll"
         )
 
-        self.dataset = datasets.load_dataset(
-            "text",
+        args = ("text",)
+        kwargs = dict(
             data_files={
                 "test": europarl_ner_german_test_path,
             },
             encoding="windows-1252",
         )
+        self._download_pushed(args, kwargs, data_dir, cache_dir, download_mode)
 
         # Convert CONLL to plain text
         self.text_docs = (

--- a/lm_eval/tasks/germeval2017.py
+++ b/lm_eval/tasks/germeval2017.py
@@ -68,7 +68,8 @@ class GermEval2017(Task):
     }
 
     def download(self, data_dir=None, cache_dir=None, download_mode=None):
-        self.dataset = datasets.load_dataset(
+        args = ()
+        kwargs = dict(
             path=self.DATASET_PATH,
             name=self.DATASET_NAME,
             data_dir=data_dir,
@@ -88,6 +89,7 @@ class GermEval2017(Task):
                 }
             ),
         )
+        self._download_pushed(args, kwargs, data_dir, cache_dir, download_mode)
 
     def has_training_docs(self):
         return True

--- a/lm_eval/tasks/oscar_ppl.py
+++ b/lm_eval/tasks/oscar_ppl.py
@@ -41,12 +41,11 @@ class OscarPerplexityGerman(PerplexityTask):
     VERSION = 0
 
     def download(self, data_dir=None, cache_dir=None, download_mode=None):
-        self.dataset = datasets.load_dataset(
-            "malteos/wechsel_de",
-            data_files={
-                "test": "valid.random_1636.json.gz",
-            },
+        args = ("malteos/wechsel_de",)
+        kwargs = dict(
+            data_files={"test": "valid.random_1636.json.gz"},
         )
+        self._download_pushed(args, kwargs, data_dir, cache_dir, download_mode)
 
     def has_training_docs(self):
         return False


### PR DESCRIPTION
Due to https://github.com/huggingface/datasets/issues/3547, caching of some task datasets fails. This means those tasks cannot run on JUWELS as an internet connection is required.

This adds optional functionality for an explicit caching mechanism to handle this problem.