### PR TITLE
Fix updating task registry too late

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -344,10 +344,10 @@ TASK_REGISTRY = {
 }
 
 
-ALL_TASKS = sorted(list(TASK_REGISTRY))
-
 # append the multilingual tasks to the registry
 TASK_REGISTRY.update(AAM_TASK_REGISTRY)
+
+ALL_TASKS = sorted(list(TASK_REGISTRY))
 
 
 def get_task(task_name):


### PR DESCRIPTION
When the `TASK_REGISTRY` is updated _after_ `ALL_TASKS` has been created, the newly added AAM tasks are missing from `ALL_TASKS`. Then, `main.py` cannot correctly check arguments for AAM tasks and will fail when it encounters such a task.