### PR TITLE
Disable unit tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -42,9 +42,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest -vv --cov=lm_eval/ tests/
+    # Tests disabled since they fail due to limited disk space of GH runner
+    #- name: Test with pytest
+    #  run: |
+    #    pytest -vv --cov=lm_eval/ tests/
     - name: Upload to codecov
       run: |
         bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN


### PR DESCRIPTION
Unit tests fail due to the limited disk space of the GH runner.

 Let's remove this since everybody ignores the failed test anyway.